### PR TITLE
Nd accessibility

### DIFF
--- a/src/css/_buttons.scss
+++ b/src/css/_buttons.scss
@@ -4,7 +4,7 @@
   background-color: $mint-green;
   border: 0;
   border-radius: 3px;
-  color: white;
+  color: black;
   cursor: pointer;
   font-family: "Quicksand", sans-serif;
   font-size: 12pt;

--- a/src/css/_header.scss
+++ b/src/css/_header.scss
@@ -4,11 +4,11 @@ header {
   grid-area: header;
   padding: 0% 0%;
   width: 100%;
-}
 
-span {
-  color: $lemon-lime;
-  font-weight: 400;
+  label {
+    color: $lemon-lime;
+    font-weight: 400;
+  }
 }
 
 .header-apple-icon {
@@ -68,7 +68,7 @@ span {
 }
 
 .search-label {
-  display: none;
+  color: white;
 }
 
 .search-btn {

--- a/src/css/_text.scss
+++ b/src/css/_text.scss
@@ -9,7 +9,7 @@ h1 {
 }
 
 h2 {
-  color: $button-hover-color;
+  color: black;
   margin: 10px 0px 10px 0px;
 }
 
@@ -22,7 +22,7 @@ h3 {
 }
 
 h4 {
-  color: $mint-green;
+  color: black;
   background-color: $lemon-lime;
   border-radius: 3px;
   margin: 10px 0px 0px 0px;

--- a/src/index.html
+++ b/src/index.html
@@ -9,41 +9,41 @@
   </head>
   <body>
     <header>
-      <h1><span>fresh</span>Picks<img src="./images/apple-logo.png" alt="apple icon" class="header-apple-icon"></h1>
-      <form id="search" role="search">
+      <h1><label>fresh</label>Picks<img src="./images/apple-logo.png" alt="apple icon" class="header-apple-icon"></h1>
+      <form id="search" role="search" aria-describedby="This is the search form where you can filter all recipe cards on the website by an ingredient or a recipe name.">
         <input id="search-input" type="text" autocomplete="off" placeholder="Search Recipes..."></input>
-        <label for="search-input" class="search-label">Search</label>
         <button class="nav-btn search-btn" type="button" name="button"><img src="./images/search.png" alt="search button"></button>
+        <label for="search-input" class="search-label">Search</label>
       </form>
-      <button class="nav-btn ing-pan-btn saved-recipes-btn" type="button" name="button"><img src="./images/cookbook.png" alt="search button">My Recipes</button>
-      <button class="nav-btn my-pantry-btn ing-pan-btn saved-ingredients-btn" type="button" name="button"><img src="./images/seasoning.png" alt="search button">My Pantry</button>
+      <button class="nav-btn ing-pan-btn saved-recipes-btn" type="button" name="button"><img src="./images/cookbook.png" alt="search button" aria-describedby="Click on this button to show which recipes you have favorited.">My Recipes</button>
+      <button class="nav-btn my-pantry-btn ing-pan-btn saved-ingredients-btn" type="button" name="button"><img src="./images/seasoning.png" alt="search button" aria-describedby="Click on this button to show the ingredients that you have inside of  your pantry.">My Pantry</button>
     </header>
     <section class="banner-image">
-      <div class="my-recipes-banner">
+      <article class="my-recipes-banner">
         <h1>My Recipes</h1>
         <button class="show-all-btn">Show All Recipes</button>
-      </div>
+      </article>
     </section>
-    <div class="drop-menu">
+    <article class="drop-menu">
       <h2>My Pantry</h2>
       <button class="show-pantry-recipes-btn">What Can I Make?</button>
       <ul class="pantry-list"></ul>
-    </div>
+    </article>
     <aside>
-      <div class="wrap">
+      <article class="wrap">
         <h2>Recipe Type</h2>
         <ul class="tag-list">
         </ul>
         <button class="filter-btn">Filter Recipes</button>
-      </div>
+      </article>
     </aside>
     <main>
-      <div class="recipe-instructions">
-      </div>
-      <div class="my-recipes-banner">
+      <article class="recipe-instructions">
+      </article>
+      <article class="my-recipes-banner">
         <h1>My Recipes</h1>
         <button class="show-all-btn">Show All Recipes</button>
-      </div>
+      </article>
     </main>
   </body>
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -11,22 +11,22 @@
     <header>
       <h1><label>fresh</label>Picks<img src="./images/apple-logo.png" alt="apple icon" class="header-apple-icon"></h1>
       <form id="search" role="search" aria-describedby="This is the search form where you can filter all recipe cards on the website by an ingredient or a recipe name.">
-        <input id="search-input" type="text" autocomplete="off" placeholder="Search Recipes..."></input>
-        <button class="nav-btn search-btn" type="button" name="button"><img src="./images/search.png" alt="search button"></button>
+        <input id="search-input" type="text" autocomplete="off" placeholder="Search Recipes..." tabindex="0"></input>
+        <button class="nav-btn search-btn" type="button" name="button" tabindex="0"><img src="./images/search.png" alt="search button"></button>
         <label for="search-input" class="search-label">Search</label>
       </form>
-      <button class="nav-btn ing-pan-btn saved-recipes-btn" type="button" name="button"><img src="./images/cookbook.png" alt="search button" aria-describedby="Click on this button to show which recipes you have favorited.">My Recipes</button>
-      <button class="nav-btn my-pantry-btn ing-pan-btn saved-ingredients-btn" type="button" name="button" aria-describedby="Click on this button to show the ingredients that you have inside of your pantry." aria-expanded="false"><img src="./images/seasoning.png" alt="search button">My Pantry</button>
+      <button class="nav-btn ing-pan-btn saved-recipes-btn" type="button" name="button" aria-describedby="Click on this button to show which recipes you have favorited." tabindex="0"><img src="./images/cookbook.png" alt="search button">My Recipes</button>
+      <button class="nav-btn my-pantry-btn ing-pan-btn saved-ingredients-btn" type="button" name="button" aria-describedby="Click on this button to show the ingredients that you have inside of your pantry." aria-expanded="false" tabindex="0"><img src="./images/seasoning.png" alt="search button">My Pantry</button>
     </header>
     <section class="banner-image">
       <article class="my-recipes-banner">
         <h1>My Recipes</h1>
-        <button class="show-all-btn">Show All Recipes</button>
+        <button class="show-all-btn" tabindex="0">Show All Recipes</button>
       </article>
     </section>
     <article class="drop-menu">
       <h2>My Pantry</h2>
-      <button class="show-pantry-recipes-btn">What Can I Make?</button>
+      <button class="show-pantry-recipes-btn" tabindex="0">What Can I Make?</button>
       <ul class="pantry-list"></ul>
     </article>
     <aside>
@@ -34,7 +34,7 @@
         <h2>Recipe Type</h2>
         <ul class="tag-list">
         </ul>
-        <button class="filter-btn">Filter Recipes</button>
+        <button class="filter-btn" tabindex="0">Filter Recipes</button>
       </article>
     </aside>
     <main>
@@ -42,7 +42,7 @@
       </article>
       <article class="my-recipes-banner">
         <h1>My Recipes</h1>
-        <button class="show-all-btn">Show All Recipes</button>
+        <button class="show-all-btn" tabindex="0">Show All Recipes</button>
       </article>
     </main>
   </body>

--- a/src/index.html
+++ b/src/index.html
@@ -16,7 +16,7 @@
         <label for="search-input" class="search-label">Search</label>
       </form>
       <button class="nav-btn ing-pan-btn saved-recipes-btn" type="button" name="button"><img src="./images/cookbook.png" alt="search button" aria-describedby="Click on this button to show which recipes you have favorited.">My Recipes</button>
-      <button class="nav-btn my-pantry-btn ing-pan-btn saved-ingredients-btn" type="button" name="button"><img src="./images/seasoning.png" alt="search button" aria-describedby="Click on this button to show the ingredients that you have inside of  your pantry.">My Pantry</button>
+      <button class="nav-btn my-pantry-btn ing-pan-btn saved-ingredients-btn" type="button" name="button" aria-describedby="Click on this button to show the ingredients that you have inside of your pantry." aria-expanded="false"><img src="./images/seasoning.png" alt="search button">My Pantry</button>
     </header>
     <section class="banner-image">
       <article class="my-recipes-banner">

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -98,7 +98,7 @@ function displayRecipeDetails(recipeInfo, shortRecipeName) {
         </article>
       </article>
       <h4>${recipeInfo.tags[0]}</h4>
-      <img src="../images/apple-logo-outline.png" alt="unfilled apple icon" class="card-apple-icon" role="button" aria-describedby="Click on this icon to favorite the ${shortRecipeName} recipe." aria-pressed="false">
+      <img src="../images/apple-logo-outline.png" alt="unfilled apple icon" class="card-apple-icon" role="button" aria-describedby="Click on this icon to favorite the ${shortRecipeName} recipe." aria-pressed="false" tabindex="0">
     </section>`
   main.insertAdjacentHTML("beforeend", cardHtml);
 }

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -65,9 +65,9 @@ function generateUser() {
   // user = new User(users[Math.floor(Math.random() * users.length)]);
   let firstName = user.name.split(" ")[0];
   let welcomeMsg = `
-    <div class="welcome-msg">
+    <section class="welcome-msg">
       <h1>Welcome ${firstName}!</h1>
-    </div>`;
+    </section>`;
   document.querySelector(".banner-image").insertAdjacentHTML("afterbegin",
     welcomeMsg);
   findPantryInfo();
@@ -89,17 +89,17 @@ function createCards(recipeData) {
 
 function displayRecipeDetails(recipeInfo, shortRecipeName) {
   let cardHtml = `
-    <div class="recipe-card" id=${recipeInfo.id}>
+    <section class="recipe-card" id=${recipeInfo.id}>
       <h3 maxlength="40">${shortRecipeName}</h3>
-      <div class="card-photo-container">
+      <article class="card-photo-container">
         <img src=${recipeInfo.image} class="card-photo-preview" alt="${recipeInfo.name} recipe" title="${recipeInfo.name} recipe">
-        <div class="text">
-          <div>Click for Instructions</div>
-        </div>
-      </div>
+        <article class="text">
+          <label>Click for Instructions</label>
+        </article>
+      </article>
       <h4>${recipeInfo.tags[0]}</h4>
       <img src="../images/apple-logo-outline.png" alt="unfilled apple icon" class="card-apple-icon">
-    </div>`
+    </section>`
   main.insertAdjacentHTML("beforeend", cardHtml);
 }
 
@@ -221,7 +221,7 @@ function openRecipeInfo(event) {
   generateRecipeTitle(recipe, generateIngredients(recipe));
   addRecipeImage(recipe);
   generateInstructions(recipe);
-  fullRecipeInfo.insertAdjacentHTML("beforebegin", "<section id='overlay'></div>");
+  fullRecipeInfo.insertAdjacentHTML("beforebegin", "<section id='overlay'></section>");
 }
 
 function generateRecipeTitle(recipe, ingredients) {

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -98,7 +98,7 @@ function displayRecipeDetails(recipeInfo, shortRecipeName) {
         </article>
       </article>
       <h4>${recipeInfo.tags[0]}</h4>
-      <img src="../images/apple-logo-outline.png" alt="unfilled apple icon" class="card-apple-icon">
+      <img src="../images/apple-logo-outline.png" alt="unfilled apple icon" class="card-apple-icon" role="button" aria-describedby="Click on this icon to favorite the ${shortRecipeName} recipe." aria-pressed="false">
     </section>`
   main.insertAdjacentHTML("beforeend", cardHtml);
 }
@@ -173,14 +173,16 @@ function hideUnselectedRecipes(foundRecipes) {
 }
 
 // FAVORITE RECIPE FUNCTIONALITY
-function addToMyRecipes() {
+function addToMyRecipes(event) {
   if (event.target.className === "card-apple-icon") {
     let cardId = parseInt(event.target.closest(".recipe-card").id)
     if (!user.favoriteRecipes.includes(cardId)) {
       event.target.src = "../images/apple-logo.png";
+      event.target.setAttribute('aria-pressed', true);
       user.saveRecipe(cardId);
     } else {
       event.target.src = "../images/apple-logo-outline.png";
+      event.target.setAttribute('aria-pressed', false);
       user.removeRecipe(cardId);
     }
   } else if (event.target.id === "exit-recipe-btn") {

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -314,8 +314,10 @@ function toggleMenu() {
   menuOpen = !menuOpen;
   if (menuOpen) {
     menuDropdown.style.display = "block";
+    pantryBtn.setAttribute('aria-expanded', true);
   } else {
     menuDropdown.style.display = "none";
+    pantryBtn.setAttribute('aria-expanded', false);
   }
 }
 


### PR DESCRIPTION
### What’s this PR do?  
- This PR changes many non-semantic HTML tags into semantic HTML tags for better accessibility.
- Adds aria-* descriptions to specific elements that a user can click or tab over.
- Allows a user to tab through elements they can interact with throughout the website.
- Changes some colors that lighthouse was showing an inconsistent contrast against.
- Raises lighthouse accessibility score to 100% for the website.
- Makes a label visible, that was previously hidden, that was causing the lighthouse score to drop by 10 points.
- Changes the code that is injected through JS to have semantic HTML tags and/or aria labels where applicable.

### Where should the reviewer start?  
- Pull these changes down.
- Run `npm start` to boot up local server and navigate to localhost:8080.

### How should this be manually tested?  
- Check for new color schemes to stay in line with the current website color schema.
- Tab through the website and make sure elements are properly being tabbed through.
- Hit `return` or `enter` when tabbing through the website to ensure all elements are keyboard accessible.

### Any background context you want to provide?  
- The buttons inside the header (search button, my recipes button and my pantry button) has it's outline hidden. However, this makes it really difficult to know, when tabbing through the website, where the keyboard tab currently is as nothing shows up when tabbing over those elements. Removing the outline from scss creates a very large outlined box around the elements that may cause some undesirable graphics that linger on the page. Looking for feedback on how to approach this to make these elements show visual feedback when tabbing without causing undesirable visuals.
- The unhidden label for the search bar is currently in a position that is not desirable. That will be addressed in the next PR while  making the website responsive and mobile friendly.

### What are the relevant tickets?  
- Closes #99
- Closes #98 
- Closes #97 
- Closes #96 
- Closes #95
- Closes #47

### Screenshots (if appropriate)  
- N/A

### Questions: 
- N/A